### PR TITLE
Adding cherrio dep in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "version": "0.0.0",
   "main": "Gruntfile.js",
   "devDependencies": {
+    "cheerio": "0.19.0",
     "del": "1.1.1",
     "gulp": "3.8.11",
     "gulp-connect": "2.2.0",


### PR DESCRIPTION
Now I'm getting this

```
adam@Planet-X -- jha-design: (add-cheerio) gulp
[08:56:37] Using gulpfile ~/src/banno/jha-design/gulpfile.js
[08:56:37] Starting 'copy'...
[08:56:37] Starting 'styles'...
[08:56:37] Starting 'icons'...
[08:56:37] Starting 'file-icons'...
[08:56:37] Starting 'images'...
[08:56:37] Starting 'connect'...
[08:56:37] Finished 'connect' after 18 ms
[08:56:37] Starting 'watch'...
[08:56:37] Finished 'watch' after 76 ms

events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: spawn sass ENOENT
    at exports._errnoException (util.js:746:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1053:32)
    at child_process.js:1144:20
    at process._tickCallback (node.js:355:11)
```
