### PR TITLE
Non required valid fields should only use has-value for floating label

### DIFF
--- a/src/css/components/forms.scss
+++ b/src/css/components/forms.scss
@@ -373,7 +373,7 @@ textarea.form-control {
 
 .floating-group.has-value .label,
 .field:focus ~ .label,
-.field:valid ~ .label {
+.field:required:valid ~ .label {
   font-size: $font-size-sm;
   font-weight: 600;
   top: 0;


### PR DESCRIPTION
When required is present we can leverage the :valid css selector to make the label floating, but non-required fields are always valid, hence the label floats even if there is no value in the input field. 

So as per documentation, `has-value` should be used if the field doesn't have the required attribute in order to make label floating.